### PR TITLE
chore: un-pin requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     keywords='circleci ci cd api sdk',
     packages=['circleci'],
     install_requires=[
-        'requests==2.18.4',
+        'requests',
     ],
     python_requires='>=3',
     cmdclass={


### PR DESCRIPTION
Hello,

Thanks for this great wrapper! I am using this in a project that pulls in a newer version of requests. This prevents me from importing the library - I get a `pkg_resources.ContextualVersionConflict` error.

It is generally not good practice to pin packages in `install_requires` [1], so I have relaxed the requirement here. There may be a good reason for this that I am unaware of.

Thanks again!

[1] https://packaging.python.org/discussions/install-requires-vs-requirements/#install-requires