### PR TITLE
Fix integration tests

### DIFF
--- a/tests/circle/test_integration.py
+++ b/tests/circle/test_integration.py
@@ -17,10 +17,10 @@ class TestCircleCIApi(unittest.TestCase):
 
     def test_trigger_with_build_params(self):
         params = {
-            "build_parameters[CIRCLE_JOB]": "test"
+            "build_parameters[CIRCLE_JOB]": "build"
         }
 
-        resp = self.c.trigger_build('levlaz', 'circleci-demo-javascript-express', params=params)
+        resp = self.c.trigger_build('levlaz', 'circleci.py', params=params)
 
         self.assertEqual(resp['build_parameters']['CIRCLE_JOB'], 'test')
 
@@ -92,11 +92,11 @@ rAUZ8tU0o5Ec6T0ZQkcous7OwBZGE+JLuFa3S6JfISLw42brjQ9dE5mosm7m2d4H
         self.assertTrue(len(resp) == 0)
 
     def test_download_artifact(self):
-        resp = self.c.get_artifacts('levlaz', 'circleci-demo-javascript-express', 59)
+        resp = self.c.get_artifacts('levlaz', 'circleci.py', 89)
 
         artifact = self.c.download_artifact(resp[0]['url'])
 
-        self.assertIn('base.css', artifact)
+        self.assertIn('style.css', artifact)
 
         artifact_with_destdir = self.c.download_artifact(resp[0]['url'], '/tmp')
 

--- a/tests/circle/test_integration.py
+++ b/tests/circle/test_integration.py
@@ -92,11 +92,11 @@ rAUZ8tU0o5Ec6T0ZQkcous7OwBZGE+JLuFa3S6JfISLw42brjQ9dE5mosm7m2d4H
         self.assertTrue(len(resp) == 0)
 
     def test_download_artifact(self):
-        resp = self.c.get_artifacts('levlaz', 'circleci.py', 89)
+        resp = self.c.get_artifacts('levlaz', 'circleci.py', 87)
 
         artifact = self.c.download_artifact(resp[0]['url'])
 
-        self.assertIn('style.css', artifact)
+        self.assertIn('circleci_api_py.html', artifact)
 
         artifact_with_destdir = self.c.download_artifact(resp[0]['url'], '/tmp')
 

--- a/tests/circle/test_integration.py
+++ b/tests/circle/test_integration.py
@@ -22,7 +22,7 @@ class TestCircleCIApi(unittest.TestCase):
 
         resp = self.c.trigger_build('levlaz', 'circleci.py', params=params)
 
-        self.assertEqual(resp['build_parameters']['CIRCLE_JOB'], 'test')
+        self.assertEqual(resp['build_parameters']['CIRCLE_JOB'], 'build')
 
     def test_add_ssh_key(self):
 


### PR DESCRIPTION
Change the repo that is being used for some of the integration tests. 

This should be refactored even more, but the goal of this PR is to just get the builds passing again. 