### PR TITLE
Fix 'build_parameters' who have to be sent as JSON

### DIFF
--- a/circleci/api.py
+++ b/circleci/api.py
@@ -693,7 +693,7 @@ class Api():
         if verb == 'GET':
             resp = requests.get(request_url, auth=auth, headers=headers)
         elif verb == 'POST':
-            resp = requests.post(request_url, auth=auth, headers=headers, data=data)
+            resp = requests.post(request_url, auth=auth, headers=headers, json=data)
         elif verb == 'DELETE':
             resp = requests.delete(request_url, auth=auth, headers=headers)
         else:


### PR DESCRIPTION
According to the CircleCi documentation, `build_parameters` must be sent as JSON.

fix: #44