### PR TITLE
Add Python 3.7 support for Pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "Topic :: Internet",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3 :: Only",
     ],
     keywords='circleci ci cd api sdk',


### PR DESCRIPTION
More and more devices are running Python 3.7 as their default version.  Pip installation is failing so I am hoping that adding Python 3.7 to the setup.py file will permit support for it.