### PR TITLE
add support for api/v2 endpoints, enable retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+circleci_api_py.html
 coverage.xml
 *.cover
 .hypothesis/

--- a/circleci/version.py
+++ b/circleci/version.py
@@ -6,7 +6,7 @@ circleci.version
 
     .. versionadded:: 1.2.0
 """
-VERSION = "2.0.0"
+VERSION = "2.1.0"
 """Current version of circleci.py."""
 
 def get_short_version():

--- a/tests/circle/test_api.py
+++ b/tests/circle/test_api.py
@@ -35,6 +35,14 @@ class TestCircleCIApi(unittest.TestCase):
 
         self.assertEqual(resp["selected_email"], 'mock+ccie-tester@circleci.com')
 
+    def test_get_project(self):
+        self.loadMock('mock_get_project_response')
+        resp = json.loads(self.c.get_project('gh/foo/bar'))
+        self.assertEqual(resp['slug'], 'gh/foo/bar')
+        self.assertEqual(resp['organization_name'], 'foo')
+        self.assertEqual(resp['name'], 'bar')
+        self.assertIn("vcs_info", resp)
+
     def test_get_projects(self):
         self.loadMock('mock_get_projects_response')
         resp = json.loads(self.c.get_projects())
@@ -117,6 +125,27 @@ class TestCircleCIApi(unittest.TestCase):
         resp = json.loads(self.c.trigger_build('ccie-tester', 'testing'))
 
         self.assertEqual(resp['reponame'], 'MOCK+testing')
+
+    def test_get_pipeline(self):
+        self.loadMock('mock_get_pipeline_response')
+        resp = json.loads(self.c.get_pipeline('dummy-pipeline-id'))
+        self.assertEqual(resp['state'], 'created')
+
+    def test_get_pipeline_config(self):
+        self.loadMock('mock_get_pipeline_config_response')
+        resp = json.loads(self.c.get_pipeline_config('dummy-pipeline-id'))
+        self.assertIn("source", resp)
+        self.assertIn("compiled", resp)
+
+    def test_get_workflow(self):
+        self.loadMock('mock_get_workflow_response')
+        resp = json.loads(self.c.get_workflow('dummy-workflow-id'))
+        self.assertEqual(resp['status'], 'running')
+
+    def test_get_workflow_jobs(self):
+        self.loadMock('mock_get_workflow_jobs_response')
+        resp = json.loads(self.c.get_workflow_jobs('dummy-workflow-id'))
+        self.assertEqual(len(resp['jobs']), 2)
 
     def test_list_checkout_keys(self):
         self.loadMock('mock_list_checkout_keys_response')

--- a/tests/circle/test_api.py
+++ b/tests/circle/test_api.py
@@ -145,7 +145,7 @@ class TestCircleCIApi(unittest.TestCase):
     def test_get_workflow_jobs(self):
         self.loadMock('mock_get_workflow_jobs_response')
         resp = json.loads(self.c.get_workflow_jobs('dummy-workflow-id'))
-        self.assertEqual(len(resp['jobs']), 2)
+        self.assertEqual(len(resp['items']), 2)
 
     def test_list_checkout_keys(self):
         self.loadMock('mock_list_checkout_keys_response')

--- a/tests/mocks/mock_get_pipeline_config_response
+++ b/tests/mocks/mock_get_pipeline_config_response
@@ -1,0 +1,1 @@
+{"source": "source configuration", "compiled": "compiled configuration"}

--- a/tests/mocks/mock_get_pipeline_response
+++ b/tests/mocks/mock_get_pipeline_response
@@ -1,0 +1,6 @@
+{"workflows": {"ids": ["dummy-workflow-id"], "total_count": 1},
+"id": "dummy-pipeline-id", "errors": [], "idempotency_key": "dummy-idempotency-key",
+"project_slug": "gh/foo/bar", "updated_at": "2019-07-01T12:34:56.123Z", "number": 1234,
+"state": "created", "created_at": "2019-07-01T12:34:56.123Z",
+"trigger": {"type": "webhook", "received_at": "2019-07-01T12:34:56.123Z"},
+"vcs": {"provider_name": "GitHub", "origin_repository_url": "https://github.com/foo/bar", "target_repository_url": "https://github.com/foo/bar", "revision": "12345", "branch": "dummy"}}

--- a/tests/mocks/mock_get_project_response
+++ b/tests/mocks/mock_get_project_response
@@ -1,0 +1,1 @@
+{"slug": "gh/foo/bar", "name": "bar", "organization_name": "foo", "vcs_info": {"vcs_url": "https://github.com/foo/bar", "provider": "GitHub", "default_branch": "master"}, "last_job_finish_time": "2019-07-01T12:34:56.123Z"}

--- a/tests/mocks/mock_get_workflow_jobs_response
+++ b/tests/mocks/mock_get_workflow_jobs_response
@@ -1,0 +1,5 @@
+{"next_page_token": null, "jobs": [{"id": "1234", "name": "job1", "type": "build", "status":
+"canceled", "start_time": "2019-04-16T15:14:30Z", "dependencies": [], "job_number": 1, "stop_time":
+"2019-04-16T15:31:42Z"}, {"id": "2345", "name": "job2", "type": "build", "status": "success",
+"start_time": "2019-04-16T15:14:31Z", "dependencies": [], "job_number": 2, "stop_time":
+"2019-04-16T15:19:01Z"}]}

--- a/tests/mocks/mock_get_workflow_jobs_response
+++ b/tests/mocks/mock_get_workflow_jobs_response
@@ -1,5 +1,5 @@
-{"next_page_token": null, "jobs": [{"id": "1234", "name": "job1", "type": "build", "status":
-"canceled", "start_time": "2019-04-16T15:14:30Z", "dependencies": [], "job_number": 1, "stop_time":
+{"next_page_token": null, "items": [{"id": "1234", "name": "job1", "type": "build", "status":
+"canceled", "started_at": "2019-04-16T15:14:30Z", "dependencies": [], "job_number": 1, "stopped_at":
 "2019-04-16T15:31:42Z"}, {"id": "2345", "name": "job2", "type": "build", "status": "success",
-"start_time": "2019-04-16T15:14:31Z", "dependencies": [], "job_number": 2, "stop_time":
+"started_at": "2019-04-16T15:14:31Z", "dependencies": [], "job_number": 2, "stopped_at":
 "2019-04-16T15:19:01Z"}]}

--- a/tests/mocks/mock_get_workflow_response
+++ b/tests/mocks/mock_get_workflow_response
@@ -1,0 +1,1 @@
+{"created_at": "2019-04-16T20:46:51Z", "id": "dummy-workflow-id", "name": "dummy-workflow", "pipeline_id": null, "pipeline_number": null, "project": {"id": "dummy-project"}, "status": "running", "stopped_at": null}


### PR DESCRIPTION
- support multiple versions of the API
- add methods for api/v2 endpoints: pipeline/:id, pipeline/:id/config, workflow/:id, workflow/:id/jobs, project/:slug
- enable retrying for failed requests (5xx)
- add `shallow` param to get recent builds